### PR TITLE
Do not hardcode hostname, absolute URLs are sufficient

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: >
   Switch to OpenStreetMap and discover how you can build beautiful maps from the world’s best map data.
 baseurl: "" # the subpath of your site, e.g. /blog
 copyright: 2013–2020 OpenStreetMap and contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA</a>
-url: https://switch2osm.github.io
+url: ""
 github_username: switch2osm
 
 # Build settings


### PR DESCRIPTION
If the hostname is hardcoded, all links in the navigation point to the publicly rolled out version, not the local development version (usually http://localhost:4000/). That's confusing and not necessary.