### PR TITLE
fix(using-tiles/index.md): add provider list link

### DIFF
--- a/using-tiles/index.md
+++ b/using-tiles/index.md
@@ -22,6 +22,6 @@ Apart from very limited testing purposes, you should not use the tiles supplied 
 
 You can get a list using the project [Leaflet-provider](http://leaflet-extras.github.io/leaflet-providers/preview/) preview although some of them are not free (require an API key).
 
-### Paid-for providers: see list.
+### Paid-for providers: 
 
-Or go on to find out how to generate and serve your own tiles.
+See [list](https://switch2osm.org/providers/). Or go on to find out how to generate and serve your own tiles.


### PR DESCRIPTION
Unexpectedly found that there was a link missing here when I read this article, "**WHERE IS THE LIST?**"