### PR TITLE
node-carto is back in Debian12 with a suitable version

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-debian-12.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-12.md
@@ -17,7 +17,7 @@ These instructions are have been written and tested against a newly-installed De
 In order to build these components, a variety of dependencies need to be installed first.  Debian doesn't come with "sudo" by default, so we'll need to log on as root to do the first part:
 
     su -
-    apt install sudo screen locate libapache2-mod-tile renderd git tar unzip wget bzip2 apache2 lua5.1 mapnik-utils python3-mapnik python3-psycopg2 python3-yaml gdal-bin npm postgresql postgresql-contrib postgis postgresql-15-postgis-3 postgresql-15-postgis-3-scripts osm2pgsql net-tools curl
+    apt install sudo screen locate libapache2-mod-tile renderd git tar unzip wget bzip2 apache2 lua5.1 mapnik-utils python3-mapnik python3-psycopg2 python3-yaml gdal-bin node-carto postgresql postgresql-contrib postgis postgresql-15-postgis-3 postgresql-15-postgis-3-scripts osm2pgsql net-tools curl
 
 While still logged on as root we'll ensure that the main user account that we are using can "sudo" to root.  You'll want to change "youruseraccount" to whatever account you are using in the line below.  Don't try and do everything below as root; it won't work.
 
@@ -97,9 +97,8 @@ Here we're assuming that we're storing the stylesheet details in a directory bel
     git clone https://github.com/gravitystorm/openstreetmap-carto
     cd openstreetmap-carto
 
-Next, we'll install a suitable version of the "carto" compiler. 
+Next, we'll check that we have installed a suitable version of the "carto" compiler. 
 
-    sudo npm install -g carto
     carto -v
 
 That should respond with a number that is at least as high as:


### PR DESCRIPTION
See: https://packages.debian.org/bookworm/node-carto

This allows to download a lot less packages from apt as we can skip installing npm, which has a LOT of dependencies. It is also cleaner to install all of the needed tools from Debian, and allows to skip an install step.

I tested it on a fresh Debian 12 install.

```console
$ apt list node-carto
Listing... Done
node-carto/stable,now 1.2.0-4 all [installed]
$ which carto
/usr/bin/carto
$ carto --version
1.2.0
```

I compared with the one installed from npm and it emits the same amount of warnings ([node-carto-warnings.log](https://github.com/switch2osm/switch2osm/files/12781810/node-carto-warnings.log)).

<details><summary>apt install node-carto</summary>

```console
$ sudo apt install node-carto
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  javascript-common libc-ares2 libjs-sprintf-js libnode108 mapnik-reference node-acorn node-ansi-regex
  node-ansi-styles node-argparse node-browserslist node-busboy node-camelcase node-caniuse-lite
  node-chroma-js node-cjs-module-lexer node-cliui node-clone node-color-convert node-color-name
  node-decamelize node-defaults node-electron-to-chromium node-esprima node-get-caller-file node-hsluv
  node-js-yaml node-lodash node-lru-cache node-picocolors node-require-directory node-semver
  node-slice-ansi node-sprintf-js node-string-width node-strip-ansi node-undici node-wcwidth.js
  node-wrap-ansi node-xtend node-y18n node-yallist node-yargs node-yargs-parser nodejs nodejs-doc
Suggested packages:
  libjs-angularjs npm
Recommended packages:
  node-millstone
The following NEW packages will be installed:
  javascript-common libc-ares2 libjs-sprintf-js libnode108 mapnik-reference node-acorn node-ansi-regex
  node-ansi-styles node-argparse node-browserslist node-busboy node-camelcase node-caniuse-lite
  node-carto node-chroma-js node-cjs-module-lexer node-cliui node-clone node-color-convert
  node-color-name node-decamelize node-defaults node-electron-to-chromium node-esprima
  node-get-caller-file node-hsluv node-js-yaml node-lodash node-lru-cache node-picocolors
  node-require-directory node-semver node-slice-ansi node-sprintf-js node-string-width node-strip-ansi
  node-undici node-wcwidth.js node-wrap-ansi node-xtend node-y18n node-yallist node-yargs
  node-yargs-parser nodejs nodejs-doc
0 upgraded, 46 newly installed, 0 to remove and 0 not upgraded.
Need to get 16,1 MB of archives.
After this operation, 84,8 MB of additional disk space will be used.
Do you want to continue? [Y/n] n
Abort.
```

</details> 

<details><summary>apt install npm</summary>

```console
$ sudo apt install npm
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  eslint gyp handlebars javascript-common libc-ares2 libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-bin
  libgdk-pixbuf2.0-common libjs-async libjs-events libjs-inherits libjs-is-typedarray libjs-prettify
  libjs-regenerate libjs-source-map libjs-sprintf-js libjs-typedarray-to-buffer libjs-util libnode-dev
  libnode108 libnotify-bin libnotify4 libssl-dev libuv1-dev node-abbrev node-acorn node-agent-base
  node-ajv node-ajv-keywords node-ampproject-remapping node-ansi-escapes node-ansi-regex
  node-ansi-styles node-anymatch node-aproba node-archy node-are-we-there-yet node-argparse node-arrify
  node-assert node-async node-async-each node-auto-bind node-babel-helper-define-polyfill-provider
  node-babel-plugin-add-module-exports node-babel-plugin-lodash node-babel-plugin-polyfill-corejs2
  node-babel-plugin-polyfill-corejs3 node-babel-plugin-polyfill-regenerator node-babel7
  node-babel7-runtime node-balanced-match node-base node-base64-js node-binary-extensions
  node-brace-expansion node-braces node-browserslist node-builtins node-busboy node-cacache
  node-cache-base node-camelcase node-caniuse-lite node-chalk node-chokidar node-chownr
  node-chrome-trace-event node-ci-info node-cjs-module-lexer node-cli-boxes node-cli-cursor
  node-cli-table node-cli-truncate node-cliui node-clone node-clone-deep node-collection-visit
  node-color-convert node-color-name node-colors node-columnify node-commander node-commondir
  node-concat-stream node-console-control-strings node-convert-source-map node-copy-concurrently
  node-core-js node-core-js-compat node-core-js-pure node-core-util-is node-coveralls node-css-loader
  node-css-selector-tokenizer node-data-uri-to-buffer node-debbundle-es-to-primitive node-debug
  node-decamelize node-decompress-response node-deep-equal node-deep-is node-defaults
  node-define-properties node-define-property node-defined node-del node-delegates node-depd node-diff
  node-doctrine node-electron-to-chromium node-encoding node-end-of-stream node-enhanced-resolve
  node-err-code node-errno node-error-ex node-es-abstract node-es-module-lexer node-es6-error
  node-escape-string-regexp node-escodegen node-eslint-scope node-eslint-utils node-eslint-visitor-keys
  node-espree node-esprima node-esquery node-esrecurse node-estraverse node-esutils node-events
  node-fancy-log node-fast-deep-equal node-fast-levenshtein node-fetch node-file-entry-cache
  node-fill-range node-find-cache-dir node-find-up node-flat-cache node-flatted node-for-in node-for-own
  node-foreground-child node-fs-readdir-recursive node-fs-write-stream-atomic node-fs.realpath
  node-function-bind node-functional-red-black-tree node-gauge node-get-caller-file node-get-stream
  node-get-value node-glob node-glob-parent node-globals node-globby node-got node-graceful-fs
  node-growl node-gyp node-has-flag node-has-unicode node-has-value node-has-values node-hosted-git-info
  node-https-proxy-agent node-iconv-lite node-icss-utils node-ieee754 node-iferr node-ignore
  node-imurmurhash node-indent-string node-inflight node-inherits node-ini node-interpret node-ip
  node-ip-regex node-is-arrayish node-is-binary-path node-is-buffer node-is-descriptor
  node-is-extendable node-is-extglob node-is-glob node-is-number node-is-path-cwd node-is-path-inside
  node-is-plain-obj node-is-plain-object node-is-primitive node-is-stream node-is-typedarray
  node-is-windows node-isarray node-isexe node-isobject node-istanbul node-jest-debbundle
  node-jest-worker node-js-tokens node-js-yaml node-jsesc node-json-buffer node-json-parse-better-errors
  node-json-schema node-json-schema-traverse node-json-stable-stringify node-json5 node-jsonify
  node-jsonparse node-kind-of node-lcov-parse node-levn node-loader-runner node-locate-path node-lodash
  node-lodash-packages node-log-driver node-lowercase-keys node-lru-cache node-make-dir node-map-visit
  node-memfs node-memory-fs node-merge-stream node-micromatch node-mime node-mime-types
  node-mimic-response node-minimatch node-minimist node-minipass node-mixin-deep node-mkdirp
  node-move-concurrently node-ms node-mute-stream node-n3 node-negotiator node-neo-async node-nopt
  node-normalize-package-data node-normalize-path node-npm-bundled node-npm-package-arg
  node-npm-run-path node-npmlog node-object-assign node-object-inspect node-object-visit node-once
  node-opener node-optimist node-optionator node-osenv node-p-cancelable node-p-limit node-p-locate
  node-p-map node-parse-json node-pascalcase node-path-dirname node-path-exists node-path-is-absolute
  node-path-is-inside node-path-type node-picocolors node-pify node-pkg-dir node-postcss
  node-postcss-modules-extract-imports node-postcss-modules-values node-postcss-value-parser
  node-prelude-ls node-process-nextick-args node-progress node-promise-inflight node-promise-retry
  node-promzard node-prr node-pump node-punycode node-quick-lru node-randombytes node-read
  node-read-package-json node-read-pkg node-readable-stream node-readdirp node-rechoir node-regenerate
  node-regenerate-unicode-properties node-regenerator-runtime node-regenerator-transform node-regexpp
  node-regexpu-core node-regjsgen node-regjsparser node-repeat-string node-require-directory
  node-resolve node-resolve-cwd node-resolve-from node-restore-cursor node-resumer node-retry
  node-rimraf node-run-queue node-safe-buffer node-schema-utils node-sellside-emitter node-semver
  node-serialize-javascript node-set-blocking node-set-immediate-shim node-set-value
  node-shebang-command node-shebang-regex node-shell-quote node-signal-exit node-slash node-slice-ansi
  node-source-list-map node-source-map node-source-map-support node-spdx-correct node-spdx-exceptions
  node-spdx-expression-parse node-spdx-license-ids node-sprintf-js node-ssri node-stack-utils
  node-string-decoder node-string-width node-strip-ansi node-strip-bom node-strip-json-comments
  node-supports-color node-tap node-tap-mocha-reporter node-tap-parser node-tapable node-tape node-tar
  node-terser node-text-table node-through node-time-stamp node-to-fast-properties node-to-regex-range
  node-tslib node-type-check node-typedarray node-typedarray-to-buffer node-undici
  node-unicode-canonical-property-names-ecmascript node-unicode-match-property-ecmascript
  node-unicode-match-property-value-ecmascript node-unicode-property-aliases-ecmascript node-union-value
  node-unique-filename node-unset-value node-uri-js node-util node-util-deprecate node-uuid
  node-v8-compile-cache node-v8flags node-validate-npm-package-license node-validate-npm-package-name
  node-watchpack node-wcwidth.js node-webassemblyjs node-webpack-sources node-which node-wide-align
  node-widest-line node-wordwrap node-wrap-ansi node-wrappy node-write node-write-file-atomic node-ws
  node-xtend node-y18n node-yallist node-yaml node-yargs node-yargs-parser nodejs nodejs-doc terser
  webpack
Suggested packages:
  node-babel-eslint node-esprima-fb node-inquirer libjs-angularjs notification-daemon libssl-doc
  node-babel-plugin-polyfill-es-shims node-babel7-debug livescript chai node-jest-diff
The following NEW packages will be installed:
  eslint gyp handlebars javascript-common libc-ares2 libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-bin
  libgdk-pixbuf2.0-common libjs-async libjs-events libjs-inherits libjs-is-typedarray libjs-prettify
  libjs-regenerate libjs-source-map libjs-sprintf-js libjs-typedarray-to-buffer libjs-util libnode-dev
  libnode108 libnotify-bin libnotify4 libssl-dev libuv1-dev node-abbrev node-acorn node-agent-base
  node-ajv node-ajv-keywords node-ampproject-remapping node-ansi-escapes node-ansi-regex
  node-ansi-styles node-anymatch node-aproba node-archy node-are-we-there-yet node-argparse node-arrify
  node-assert node-async node-async-each node-auto-bind node-babel-helper-define-polyfill-provider
  node-babel-plugin-add-module-exports node-babel-plugin-lodash node-babel-plugin-polyfill-corejs2
  node-babel-plugin-polyfill-corejs3 node-babel-plugin-polyfill-regenerator node-babel7
  node-babel7-runtime node-balanced-match node-base node-base64-js node-binary-extensions
  node-brace-expansion node-braces node-browserslist node-builtins node-busboy node-cacache
  node-cache-base node-camelcase node-caniuse-lite node-chalk node-chokidar node-chownr
  node-chrome-trace-event node-ci-info node-cjs-module-lexer node-cli-boxes node-cli-cursor
  node-cli-table node-cli-truncate node-cliui node-clone node-clone-deep node-collection-visit
  node-color-convert node-color-name node-colors node-columnify node-commander node-commondir
  node-concat-stream node-console-control-strings node-convert-source-map node-copy-concurrently
  node-core-js node-core-js-compat node-core-js-pure node-core-util-is node-coveralls node-css-loader
  node-css-selector-tokenizer node-data-uri-to-buffer node-debbundle-es-to-primitive node-debug
  node-decamelize node-decompress-response node-deep-equal node-deep-is node-defaults
  node-define-properties node-define-property node-defined node-del node-delegates node-depd node-diff
  node-doctrine node-electron-to-chromium node-encoding node-end-of-stream node-enhanced-resolve
  node-err-code node-errno node-error-ex node-es-abstract node-es-module-lexer node-es6-error
  node-escape-string-regexp node-escodegen node-eslint-scope node-eslint-utils node-eslint-visitor-keys
  node-espree node-esprima node-esquery node-esrecurse node-estraverse node-esutils node-events
  node-fancy-log node-fast-deep-equal node-fast-levenshtein node-fetch node-file-entry-cache
  node-fill-range node-find-cache-dir node-find-up node-flat-cache node-flatted node-for-in node-for-own
  node-foreground-child node-fs-readdir-recursive node-fs-write-stream-atomic node-fs.realpath
  node-function-bind node-functional-red-black-tree node-gauge node-get-caller-file node-get-stream
  node-get-value node-glob node-glob-parent node-globals node-globby node-got node-graceful-fs
  node-growl node-gyp node-has-flag node-has-unicode node-has-value node-has-values node-hosted-git-info
  node-https-proxy-agent node-iconv-lite node-icss-utils node-ieee754 node-iferr node-ignore
  node-imurmurhash node-indent-string node-inflight node-inherits node-ini node-interpret node-ip
  node-ip-regex node-is-arrayish node-is-binary-path node-is-buffer node-is-descriptor
  node-is-extendable node-is-extglob node-is-glob node-is-number node-is-path-cwd node-is-path-inside
  node-is-plain-obj node-is-plain-object node-is-primitive node-is-stream node-is-typedarray
  node-is-windows node-isarray node-isexe node-isobject node-istanbul node-jest-debbundle
  node-jest-worker node-js-tokens node-js-yaml node-jsesc node-json-buffer node-json-parse-better-errors
  node-json-schema node-json-schema-traverse node-json-stable-stringify node-json5 node-jsonify
  node-jsonparse node-kind-of node-lcov-parse node-levn node-loader-runner node-locate-path node-lodash
  node-lodash-packages node-log-driver node-lowercase-keys node-lru-cache node-make-dir node-map-visit
  node-memfs node-memory-fs node-merge-stream node-micromatch node-mime node-mime-types
  node-mimic-response node-minimatch node-minimist node-minipass node-mixin-deep node-mkdirp
  node-move-concurrently node-ms node-mute-stream node-n3 node-negotiator node-neo-async node-nopt
  node-normalize-package-data node-normalize-path node-npm-bundled node-npm-package-arg
  node-npm-run-path node-npmlog node-object-assign node-object-inspect node-object-visit node-once
  node-opener node-optimist node-optionator node-osenv node-p-cancelable node-p-limit node-p-locate
  node-p-map node-parse-json node-pascalcase node-path-dirname node-path-exists node-path-is-absolute
  node-path-is-inside node-path-type node-picocolors node-pify node-pkg-dir node-postcss
  node-postcss-modules-extract-imports node-postcss-modules-values node-postcss-value-parser
  node-prelude-ls node-process-nextick-args node-progress node-promise-inflight node-promise-retry
  node-promzard node-prr node-pump node-punycode node-quick-lru node-randombytes node-read
  node-read-package-json node-read-pkg node-readable-stream node-readdirp node-rechoir node-regenerate
  node-regenerate-unicode-properties node-regenerator-runtime node-regenerator-transform node-regexpp
  node-regexpu-core node-regjsgen node-regjsparser node-repeat-string node-require-directory
  node-resolve node-resolve-cwd node-resolve-from node-restore-cursor node-resumer node-retry
  node-rimraf node-run-queue node-safe-buffer node-schema-utils node-sellside-emitter node-semver
  node-serialize-javascript node-set-blocking node-set-immediate-shim node-set-value
  node-shebang-command node-shebang-regex node-shell-quote node-signal-exit node-slash node-slice-ansi
  node-source-list-map node-source-map node-source-map-support node-spdx-correct node-spdx-exceptions
  node-spdx-expression-parse node-spdx-license-ids node-sprintf-js node-ssri node-stack-utils
  node-string-decoder node-string-width node-strip-ansi node-strip-bom node-strip-json-comments
  node-supports-color node-tap node-tap-mocha-reporter node-tap-parser node-tapable node-tape node-tar
  node-terser node-text-table node-through node-time-stamp node-to-fast-properties node-to-regex-range
  node-tslib node-type-check node-typedarray node-typedarray-to-buffer node-undici
  node-unicode-canonical-property-names-ecmascript node-unicode-match-property-ecmascript
  node-unicode-match-property-value-ecmascript node-unicode-property-aliases-ecmascript node-union-value
  node-unique-filename node-unset-value node-uri-js node-util node-util-deprecate node-uuid
  node-v8-compile-cache node-v8flags node-validate-npm-package-license node-validate-npm-package-name
  node-watchpack node-wcwidth.js node-webassemblyjs node-webpack-sources node-which node-wide-align
  node-widest-line node-wordwrap node-wrap-ansi node-wrappy node-write node-write-file-atomic node-ws
  node-xtend node-y18n node-yallist node-yaml node-yargs node-yargs-parser nodejs nodejs-doc npm terser
  webpack
0 upgraded, 399 newly installed, 0 to remove and 0 not upgraded.
Need to get 29,5 MB of archives.
After this operation, 180 MB of additional disk space will be used.
Do you want to continue? [Y/n] n
Abort.
```

</details> 