### PR TITLE
Fix githubio links

### DIFF
--- a/find-out-more.md
+++ b/find-out-more.md
@@ -36,7 +36,7 @@ OpenStreetMap is a decentralised, volunteer-run project so there’s no single c
 Please contact the OSM Foundation’s Communications Working Group.
 
 # About switch2osm
-Switch2osm is a community driven site coordinated by [Richard Fairhurst](http://www.systemed.net/) and [Paul Norman](http://www.paulnorman.ca/) with huge amounts of help from the OpenStreetMap community. You can [get involved on GitHub](https://github.com/switch2osm/switch2osm.github.io)
+Switch2osm is a community driven site coordinated by [Richard Fairhurst](http://www.systemed.net/) and [Paul Norman](http://www.paulnorman.ca/) with huge amounts of help from the OpenStreetMap community. You can [get involved on GitHub](https://github.com/switch2osm/switch2osm)
 
 Comments or suggestions? Please make contact via IRC at the first instance.
 

--- a/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-16-04-2-lts.md
@@ -369,4 +369,4 @@ In your switcheroo-configured Chrome / Chromium browser go to: https://www.opens
 
 and switch to the "Humanitarian" layer in OSM. You should see some tile requests. Zoom out gradually. You'll see requests for new tiles show up in the ssh connection. Some low-zoom tiles may take a long time (several minutes) to render for the first time, but once done they'll be ready for the next time that they are needed.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-18-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-18-04-lts.md
@@ -375,4 +375,4 @@ That will show a line every time a tile is requested, and one every time renderi
 
 When you load that page you should see some tile requests. Zoom out gradually. You’ll see requests for new tiles show up in the ssh connection. Some low-zoom tiles may take a long time (several minutes) to render for the first time, but once done they’ll be ready for the next time that they are needed.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-20-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-20-04-lts.md
@@ -358,4 +358,4 @@ That will show a line every time a tile is requested, and one every time renderi
 
 When you load that page you should see some tile requests. Zoom out gradually. You’ll see requests for new tiles show up in the ssh connection. Some low-zoom tiles may take a long time (several minutes) to render for the first time, but once done they’ll be ready for the next time that they are needed.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-debian-11.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-11.md
@@ -261,4 +261,4 @@ The initial map display will take a little while.  You'll be able to zoom in and
 
 If desired, you can increase the setting "ModTileMissingRequestTimeout" in "/etc/apache2/conf-available/renderd.conf" from 10 seconds to perhaps 30 or 60, in order to wait longer for tiles to be rendered in the background before a grey tile is given to the user.  Make sure you "sudo service renderd restart" and "sudo service apache2 restart" after changing it.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-debian-12.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-12.md
@@ -294,4 +294,4 @@ The initial map display will take a little while.  You'll be able to zoom in and
 
 If desired, you can increase the settings "ModTileRequestTimeout" and "ModTileMissingRequestTimeout" in "/etc/apache2/conf-available/renderd.conf" from 3 and 10 seconds to perhaps 30 or 60, in order to wait longer for tiles to be rendered in the background before a grey tile is given to the user.  Make sure you "sudo service renderd restart" and "sudo service apache2 restart" after changing it.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-ubuntu-21.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-21.md
@@ -257,4 +257,4 @@ The initial map display will take a little while.  You'll be able to zoom in and
 
 If desired, you can increase the setting “ModTileMissingRequestTimeout” in “/etc/apache2/conf-available/renderd.conf” from 10 seconds to perhaps 30 or 60, in order to wait longer for tiles to be rendered in the background before a grey tile is given to the user. Make sure you “sudo service renderd restart” and “sudo service apache2 restart” after changing it.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.

--- a/serving-tiles/manually-building-a-tile-server-ubuntu-22-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-22-04-lts.md
@@ -278,4 +278,4 @@ That will show a line every time a tile is requested, and one every time renderi
 
 If desired, you can increase the setting “ModTileMissingRequestTimeout” in “/etc/apache2/conf-available/renderd.conf” from 10 seconds to perhaps 30 or 60, in order to wait longer for tiles to be rendered in the background before a grey tile is given to the user. Make sure you “sudo service renderd restart” and “sudo service apache2 restart” after changing it.
 
-Congratulations. Head over to the [using tiles](https://switch2osm.github.io/using-tiles/) section to create a map that uses your new tile server.
+Congratulations. Head over to the [using tiles](https://switch2osm.org/using-tiles/) section to create a map that uses your new tile server.


### PR DESCRIPTION
switch2osm.github.io has moved to switch2osm.org; correct broken links