### PR TITLE
Addressing #271 in the other 3 "latest versions".

### DIFF
--- a/serving-tiles/manually-building-a-tile-server-debian-11.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-11.md
@@ -98,6 +98,10 @@ Here we're assuming that we're storing the stylesheet details in a directory bel
     cd ~/src
     git clone https://github.com/gravitystorm/openstreetmap-carto
     cd openstreetmap-carto
+    git pull --all
+    git switch --detach v5.9.0
+
+The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto is in the process of moving to a different database format.  See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.
 
 Next, we'll install a suitable version of the "carto" compiler. 
 

--- a/serving-tiles/manually-building-a-tile-server-debian-12.md
+++ b/serving-tiles/manually-building-a-tile-server-debian-12.md
@@ -99,7 +99,7 @@ Here we're assuming that we're storing the stylesheet details in a directory bel
     git pull --all
     git switch --detach v5.9.0
 
-The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto is in the process of moving to a different database format.  See OSM CArto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.
+The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto is in the process of moving to a different database format.  See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.
 
 Next, we'll check that we have installed a suitable version of the "carto" compiler. 
 

--- a/serving-tiles/manually-building-a-tile-server-ubuntu-22-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-22-04-lts.md
@@ -92,6 +92,10 @@ Here we're assuming that we're storing the stylesheet details in a directory bel
     cd ~/src
     git clone https://github.com/gravitystorm/openstreetmap-carto
     cd openstreetmap-carto
+    git pull --all
+    git switch --detach v5.9.0
+
+The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto is in the process of moving to a different database format.  See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.
 
 Next, we'll install a suitable version of the "carto" compiler. 
 

--- a/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
+++ b/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
@@ -92,6 +92,10 @@ Here we're assuming that we're storing the stylesheet details in a directory bel
     cd ~/src
     git clone https://github.com/gravitystorm/openstreetmap-carto
     cd openstreetmap-carto
+    git pull --all
+    git switch --detach v5.9.0
+
+The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto is in the process of moving to a different database format.  See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.
 
 Next, we'll install a suitable version of the "carto" compiler. 
 


### PR DESCRIPTION
Minor formatting change to Debian 12.
No change to Docker; the upstream dockerfile targets 5.4.0.