### PR TITLE
Update the mkdocs.yml to accurately define the menu structure for the Maplibre article.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,8 @@ plugins:
             # Menu item name for the side menu
             OpenLayers: Getting started with OpenLayers
             # Menu item name for the side menu
+            MapLibre: Getting started with MapLibre GL
+            # Menu item name for the side menu
             Vector Tiles: Power of Vector Map Tiles
             # Menu item name for the "Serving Tiles" tab
             Serving: Serving Tiles


### PR DESCRIPTION
```diff
# Menu item name for the side menu
OpenLayers: Getting started with OpenLayers
+ # Menu item name for the side menu
+  MapLibre: Getting started with MapLibre GL
# Menu item name for the side menu
Vector Tiles: Power of Vector Map Tiles
```

Added to mkdocs.yml to provide a comprehensive definition of the full text menu.

Depends on: PR #320 
