### PR TITLE
Fix to typo in Using Tiles#Choosing an API/library page in English

### DIFF
--- a/docs/en/using-tiles/index.md
+++ b/docs/en/using-tiles/index.md
@@ -10,7 +10,7 @@ You can switch a website to OpenStreetMap in under an hour. Choose a JavaScript 
 
 ## Choosing an API/library
 
-Unlike commercial online map providers, OpenStreetMap does not provide an “official” JavaScript library which you are required to use. Rather, you can use any library that meets your needs. The most popular is Leaflet, an open-source library. OpenLayers 3, another well know library, can also be a good fit.
+Unlike commercial online map providers, OpenStreetMap does not provide an “official” JavaScript library which you are required to use. Rather, you can use any library that meets your needs. The most popular is Leaflet, an open-source library. OpenLayers 3, another well-known library, can also be a good fit.
 
 [Getting started with Leaflet – a light web maps library](/using-tiles/getting-started-with-leaflet.md)
 


### PR DESCRIPTION
Fixing a typo in the Using Tiles#Choosing an API/library page on the English version (well know -> well-known)