### PR TITLE
protomaps.com/extracts URL changed to slice.openstreetmap.us

### DIFF
--- a/docs/en/serving-tiles/index.md
+++ b/docs/en/serving-tiles/index.md
@@ -31,7 +31,7 @@ Serving your own maps is a fairly intensive task. Depending on the size of the a
 We would recommend that you begin with extracts of OpenStreetMap data – for example, a city, county or small country – rather than spending a week importing the whole world (planet.osm) and then having to restart because of a configuration mistake! You can download extracts from:
 
 * [Geofabrik](https://download.geofabrik.de/){: target=_blank} (countries and provinces)
-* [Protomaps Extracts](https://protomaps.com/extracts){: target=_blank} (minutely-updated cities and small countries)
+* [slice.openstreetmap.us](https://slice.openstreetmap.us){: target=_blank} (minutely-updated cities and small countries)
 * [download.openstreetmap.fr](https://download.openstreetmap.fr/){: target=_blank}
 
 ## The toolchain

--- a/docs/uk/serving-tiles/index.md
+++ b/docs/uk/serving-tiles/index.md
@@ -31,7 +31,7 @@ lang: uk
 Ми радимо вам розпочати роботу з невеличких частин даних OpenStreetMap&nbsp;– з міста, району чи області. Це краще ніж витратити тиждень на імпорт всього світу (planet.osm) і потім почати все наново після виявлення помилки в налаштуваннях! Ви можете завантажити дані частинами з:
 
 * [Geofabrik](https://download.geofabrik.de/){: target=_blank} (країни та регіони)
-* [Protomaps Extracts](https://protomaps.com/extracts){: target=_blank} (щохвилинні оновлення міст та невеличких країн)
+* [slice.openstreetmap.us](https://slice.openstreetmap.us){: target=_blank} (щохвилинні оновлення міст та невеличких країн)
 * [download.openstreetmap.fr](https://download.openstreetmap.fr/){: target=_blank}
 
 ## Інструментарій


### PR DESCRIPTION
Update link, that's it.