### PR TITLE
Use systemd override files for customization

### DIFF
--- a/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
@@ -333,7 +333,7 @@ sudo systemctl reload apache2
 It'd be really useful at this point to be able to see the output from the tile rendering process, including any errors. By default, with recent `mod_tile` versions, this is turned off. To turn it on:
 
 ```sh
-sudo nano /usr/lib/systemd/system/renderd.service
+sudo systemctl edit renderd.service
 ```
 
 If it's not already there below `[Service]`, add:

--- a/docs/en/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md
@@ -306,7 +306,7 @@ sudo systemctl reload apache2
 It'd be really useful at this point to be able to see the output from the tile rendering process, including any errors.  By default with recent mod_tile versions, this is turned off.  To turn it on:
 
 ```sh
-sudo nano /usr/lib/systemd/system/renderd.service
+sudo systemctl edit renderd.service
 ```
 
 If it's not already there below `[Service]`, add:


### PR DESCRIPTION
Editing the service in /usr/lib will be ovewritten when the package will be updated. systemd provides an override option with files in services.d/override.conf which can be automatically used with systemctl edit.