### PR TITLE
Switch vector tiles from glyphs to using webfonts

### DIFF
--- a/docs/assets/using-tiles/build.ts
+++ b/docs/assets/using-tiles/build.ts
@@ -3,8 +3,11 @@ import { writeFileSync } from "node:fs";
 
 const style = colorful({
     baseUrl: "https://example.com",
-    glyphs: "/fonts/{fontstack}/{range}.pbf",
+    fonts: { regular: "Noto Sans", bold: "Noto Sans Bold" },
     sprite: [{ id: 'basics', url: "/sprites/basics/sprites" }],
     tiles: ["https://vector.openstreetmap.org/shortbread_v1/{z}/{x}/{y}.mvt"]
 });
+
+// We're using web fonts so we don't need glyphs
+delete style.glyphs;
 writeFileSync("release/style.json", JSON.stringify(style));

--- a/docs/en/using-tiles/getting-started-with-maplibre.md
+++ b/docs/en/using-tiles/getting-started-with-maplibre.md
@@ -35,7 +35,7 @@ We're going to be using the VersaTiles colorful style, a basic style which uses 
 !!! info ""
     Usage of the vector tiles is governed by the [vector tile usage policy](https://operations.osmfoundation.org/policies/vector/). This web page will meet the requirements, but there is no SLA or guarantee with the vector tile service. If you need these you should host them yourself or use a commercial host.
 
-A style requires a style definition, sprite files for any icons, and glyph files for any fonts. We're going to build the style definition to point to our own sprite and glyph files.
+A style requires a style definition and sprite files for any icons. We're going to build the style definition to point to our own sprites.
 
 Start by making a new directory to store the files you'll be creating. We'll call it "style" in the documentation, but it can be whatever you want. Inside this directory we're going to build all the files we need and place them in a "release" subdirectory
 
@@ -45,19 +45,15 @@ cd style
 mkdir release
 ```
 
-Building sprites and glyphs can be a complicated process, but because we don't need to modify them we're going to use pre-built ones
+Building sprites can be a complicated process, but because we don't need to modify them we're going to use pre-built ones
 
 ```sh
 curl -OL https://github.com/versatiles-org/versatiles-style/releases/download/v5.10.0/sprites.tar.gz
 mkdir -p release/sprites
 tar -C release/sprites -xzf sprites.tar.gz
-
-curl -OL https://github.com/versatiles-org/versatiles-fonts/releases/download/v2.1.0/fonts.tar.gz
-mkdir -p release/fonts
-tar -C release/fonts -xzf fonts.tar.gz
 ```
 
-We now need to build the style so it uses our new copy of the glyphs and sprites.
+We now need to build the style so it uses our new copy of the sprites and the OSMF vector tile service.
 
 Copy the following content to a file [build.ts](build.ts){: target=_blank}, but change "example.com" to the URL that you will serve the tiles from, including your domain name
 

--- a/docs/en/using-tiles/maplibre.html
+++ b/docs/en/using-tiles/maplibre.html
@@ -2,6 +2,9 @@
 <html>
 <head>
   <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
   <script src='https://unpkg.com/maplibre-gl@5.21/dist/maplibre-gl.js'></script>
   <link href='https://unpkg.com/maplibre-gl@5.21/dist/maplibre-gl.css' rel='stylesheet' />
 
@@ -12,19 +15,29 @@
 <body>
   <div id="map"></div>
   <script>
-    maplibregl.setRTLTextPlugin(
-        'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.4.0/dist/mapbox-gl-rtl-text.js',
-        true // Lazy load the plugin
-    );
-    
-    const map = new maplibregl.Map({
-      style: new URL('style.json', window.location.href).href,
-      container: 'map',
-      center: [0, 0],
-      zoom: 1,
-      hash: true,
-      maxZoom: 19
-    });
+    // Pre-load the fonts
+    const fonts = ["Noto Sans", "Noto Sans Bold"];
+    Promise.all(fonts.map(font => {
+      try {
+        return document.fonts.load(`24px '${font}'`);
+      } catch (e) {
+        // Swallow any font loading error so the map keeps loading
+      }
+    })).then(() => {
+      maplibregl.setRTLTextPlugin(
+          'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.4.0/dist/mapbox-gl-rtl-text.js',
+          true // Lazy load the plugin
+      );
+
+      const map = new maplibregl.Map({
+        style: new URL('style.json', window.location.href).href,
+        container: 'map',
+        center: [0, 0],
+        zoom: 1,
+        hash: true,
+        maxZoom: 19
+      });
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
This builds on the version updates in #349. Web fonts have better support for complex scripts and are much simpler to deploy with.