### PR TITLE
Remove python3-mapnik from instructions for Debian 13

### DIFF
--- a/docs/assets/serving-tiles/debian13-deps.txt
+++ b/docs/assets/serving-tiles/debian13-deps.txt
@@ -2,9 +2,9 @@ su -
 apt install \
     sudo screen locate libapache2-mod-tile \
     renderd git tar unzip wget bzip2 apache2 \
-    lua5.1 mapnik-utils python3-mapnik \
-    python3-psycopg2 python3-yaml gdal-bin \
-    node-carto postgresql postgresql-contrib \
-    postgis postgresql-17-postgis-3 \
+    lua5.1 mapnik-utils python3-psycopg2 \
+    python3-yaml gdal-bin node-carto \
+    postgresql postgresql-contrib postgis \
+    postgresql-17-postgis-3 \
     postgresql-17-postgis-3-scripts osm2pgsql \
     net-tools curl

--- a/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
@@ -106,16 +106,14 @@ exit
 
 Mapnik was installed above. We'll check that it has been installed correctly by doing this:
 
-```py
-python3
->>> import mapnik
->>>
+```sh
+mapnik-render --version
 ```
 
-If python replies with the second chevron prompt `>>>` and without errors, then Mapnik library was found by Python. Congratulations! You can leave Python with this command:
+It should reply with the version number of Mapnik:
 
-```py
->>> quit()
+```sh
+version 4.0.7
 ```
 
 ## Stylesheet configuration


### PR DESCRIPTION
It is used to test if Mapnik is installed. This can be achieved using `mapnik-render --version`, too.

Someone tried to follow the guide for Debian 13 on Kali Linux at Berlin Hack Weekend yesterday and failed because Kali Linux (based on Debian) does not package `python3-mapnik`. When I looked at their issue, I was surprised to see this package in the list and wondered why it is requiered at all. The sole purpose of Mapnik's Python bindings in this guide is testing the installation. The same can be achieved with `mapnik-render --version`. That is part of the `mapnik-utils` package and installed as instructed by the guide.

Python-Mapnik is a piece of software, I don't want to rely on. It does not have any releases. This and other reasons motivated me to port Nik4 to C++ and call it [Nik5](https://codeberg.org/Geofabrik/Nik5).

The Ukrainian translation needs an update after my change. Can I somehow mark it as outdated?

Should I apply this change to other guides, too?