### PR TITLE
Debian 13 flex

### DIFF
--- a/docs/en/serving-tiles/index.md
+++ b/docs/en/serving-tiles/index.md
@@ -20,7 +20,7 @@ If you are setting up your own tile server, we recommend that you use [Ubuntu Li
 
 ## The options
 
-1. Install locally on [Debian 13](manually-building-a-tile-server-debian-13.md), [Debian 12](manually-building-a-tile-server-debian-12.md), [Ubuntu 24.04](manually-building-a-tile-server-ubuntu-24-04-lts.md), or [Debian 11](manually-building-a-tile-server-debian-11.md).
+1. Install locally on [Debian 13 (pgsql)](manually-building-a-tile-server-debian-13.md), [Debian 13 (flex)](manually-building-a-tile-server-debian-13-flex.md), [Debian 12](manually-building-a-tile-server-debian-12.md), [Ubuntu 24.04](manually-building-a-tile-server-ubuntu-24-04-lts.md), or [Debian 11](manually-building-a-tile-server-debian-11.md).
 
 2. Use [docker](using-a-docker-container.md).
 

--- a/docs/en/serving-tiles/manually-building-a-tile-server-debian-13-flex.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-debian-13-flex.md
@@ -1,0 +1,403 @@
+---
+layout: docs
+title: Manually building a tile server (Debian 13)
+dist: Debian 13
+dl_timestamp: "2025-08-15T12:40:00Z"
+lang: en
+---
+
+# {{ title }}
+
+!!! info ""
+    This page describes how to install, setup and configure all the necessary software to operate your own tile server. These step-by-step instructions were written for [Debian Linux](https://www.debian.org/){: target=_blank} 13 (trixie), and were tested in August 2025.
+
+## Software installation
+
+The OSM tile server stack is a collection of programs and libraries that work together to create a tile server. As so often with OpenStreetMap, there are many ways to achieve this goal, and nearly all of the components have alternatives that have various specific advantages and disadvantages. This tutorial describes the most standard version that is similar to that used on the main OpenStreetMap.org tile servers.
+
+It consists of 5 main components: `mod_tile`, `renderd`, `mapnik`, `osm2pgsql` and a `postgresql/postgis` database. Mod_tile is an apache module that serves cached tiles and decides which tiles need re-rendering&nbsp;– either because they are not yet cached or because they are outdated. Renderd provides a priority queueing system for different sorts of requests to manage and smooth out the load from rendering requests. Mapnik is the software library that does the actual rendering and is used by `renderd`.
+
+These instructions have been written and tested against a new {{ dist }} server. If you have got other versions of some software already installed (perhaps you upgraded from an earlier version some time ago, or you set up some PPAs to load from) then you may need to make some adjustments.
+
+In order to build these components, a variety of dependencies need to be installed first.
+
+Debian may not come with `sudo` by default, so we may need to log on as `root` to do the first part:
+
+```sh
+--8<-- "docs/assets/serving-tiles/debian13-deps.txt"
+```
+
+While still logged on as root we'll ensure that the main user account that we are using can `sudo` to root. You'll want to change `youruseraccount` to whatever account you are using in the line below. Don't try and do everything below as `root`; it won't work.
+
+```sh
+usermod -aG sudo youruseraccount
+exit
+```
+
+That returns to your user account. Logoff and logon again, and then:
+
+```sh
+sudo whoami
+```
+
+That should return `root`.
+
+At this point, a couple of new accounts have been added. You can see them with `tail /etc/passwd`. `postgres` is used for managing the databases that we use to hold data for rendering. `_renderd` is used for the `renderd` daemon, and we'll need to make sure lots of the commands below are run as that user.
+
+Now you need to create a postgis database. The defaults of various programs assume the database is called `gis` and we will use the same convention in this tutorial, although this is not necessary. Note that `_renderd` below matches the user that the `renderd` daemon will run from.
+
+```sh
+sudo -u postgres -i
+createuser _renderd
+createdb -E UTF8 -O _renderd gis
+```
+
+While still working as the `postgres` user, set up PostGIS on the PostgreSQL database:
+
+```sh
+psql
+```
+
+(that'll put you at a `postgres=#` prompt)
+
+```sh
+\c gis
+```
+
+(it'll answer "You are now connected to database 'gis' as user 'postgres'".)
+
+```sql
+CREATE EXTENSION postgis;
+```
+
+(it'll answer CREATE EXTENSION)
+
+```sql
+CREATE EXTENSION hstore;
+```
+
+(it'll answer CREATE EXTENSION)
+
+```sh
+\q
+```
+
+(it'll exit psql and go back to a normal Linux prompt)
+
+```sh
+exit
+```
+
+(to exit back to be the user that we were before we did `sudo -u postgres -i` above)
+
+## Mapnik
+
+Mapnik was installed above. We'll check that it has been installed correctly by doing this:
+
+```sh
+mapnik-render --version
+```
+
+It should reply with the version number of Mapnik:
+
+```sh
+version 4.0.7
+```
+
+## Stylesheet configuration
+
+Now that all of the necessary software is installed, you will need to download and configure a stylesheet.
+
+The style we'll use here is the one that use by the "standard" map on the openstreetmap.org website. It's chosen because it's well documented, and should work anywhere in the world (including in places with non-latin placenames). There are a couple of downsides though - it's very much a compromise designed to work globally, and it's quite complicated to understand and modify, should you need to do that.
+
+The home of "OpenStreetMap Carto" on the web is <https://github.com/gravitystorm/openstreetmap-carto/>{: target=_blank}, and it has its own installation instructions at <https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md>{: target=_blank}, although we'll cover everything that needs to be done here.
+
+Here we're assuming that we're storing the stylesheet details in a directory below `~/src` below the home directory of the whichever non-root account you are using:
+
+```sh
+mkdir ~/src
+cd ~/src
+git clone https://github.com/gravitystorm/openstreetmap-carto
+cd openstreetmap-carto
+git pull --all
+```
+
+Note that OSM Carto has now moved to a different database format - see OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for more details.  The old format was called `pgsql`, the new one is `flex`.
+
+Next, we'll check that we have installed a suitable version of the `carto` compiler.
+
+```sh
+carto -v
+```
+
+That should respond with a number that is at least as high as:
+
+```log
+1.2.0
+```
+
+Then we convert the carto project into something that Mapnik can understand:
+
+```sh
+carto project.mml > mapnik.xml
+```
+
+You now have a Mapnik XML stylesheet at `/home/youraccountname/src/openstreetmap-carto/mapnik.xml`.
+
+## Loading data
+
+Initially, we'll load only a small amount of test data. Other download locations are available, but `download.geofabrik.de` has a wide range of options. In this example we'll download the data for Azerbaijan, which is currently about 32Mb.
+
+Browse to <https://download.geofabrik.de/asia/azerbaijan.html>{: target=_blank} and note the "This file was last modified" date (e.g. "{{ dl_timestamp }}"). We'll need that later if we want to update the database with people's subsequent changes to OpenStreetMap. Download it as follows:
+
+```sh
+mkdir ~/data
+cd ~/data
+wget https://download.geofabrik.de/asia/azerbaijan-latest.osm.pbf
+```
+
+Next, we need to make sure that the `_renderd` user can access the stylesheet. In order to do this it needs access to wherever you downloaded it, and by default it won't have access to your home directory. If it's in `src` below your user account then
+
+```sh
+chmod o+rx ~
+```
+
+will work. If you don't want to do this you can move it and amend references to the file locations in subsequent commands.
+
+The following command will insert the OpenStreetMap data you downloaded earlier into the database. This step is very disk I/O intensive; importing the full planet might take many hours, days or weeks depending on the hardware. For smaller extracts the import time is much faster accordingly, and you may need to experiment with different `-C` values to fit within your machine's available memory. Note that the `_renderd` user is used for this process.
+
+```sh
+sudo -u _renderd \
+    osm2pgsql -O flex -S ~/src/openstreetmap-carto/openstreetmap-carto-flex.lua -d gis \
+    --create --slim -C 2500 --number-processes 1 \
+    ~/data/azerbaijan-latest.osm.pbf
+```
+
+It's worth explaining a little bit about what those options mean:
+
+`-O flex`
+: We're using `flex` rather than `pgsql` output.
+
+`-S ~/src/openstreetmap-carto/openstreetmap-carto-flex.lua`
+: Defines the lua script used for tag processing. This an easy is a way to process OSM tags before the style itself processes them, making the style logic potentially much simpler.
+
+`-d gis`
+: The database to work with (`gis` used to be the default; now it must be specified).
+
+`--slim`
+: We're using `slim` mode; we can update the database after importing it.
+
+`-C 2500`
+: Allocate 2.5 Gb of memory to osm2pgsql to the import process. If you have less memory you could try a smaller number, and if the import process is killed because it runs out of memory you'll need to try a smaller number or a smaller OSM extract.
+
+`--number-processes 1`
+: Use 1 CPU. If you have more cores available you can use more.
+
+`~/data/azerbaijan-latest.osm.pbf`
+: The final argument is the data file to load.
+
+That command will complete with something like "Osm2pgsql took 238s overall".
+
+### Disable JIT
+
+This is [recommended](https://github.com/openstreetmap-carto/openstreetmap-carto/blob/master/INSTALL.md#disable-jit) by the OSM Carto authors.
+
+```sh
+sudo -u _renderd psql -d gis -c 'ALTER SYSTEM SET jit=off;' -c 'SELECT pg_reload_conf();'
+```
+
+### Creating indexes
+
+Some extra indexes now need to be [applied manually](https://github.com/gravitystorm/openstreetmap-carto/blob/master/CHANGELOG.md#v530---2021-01-28){: target=_blank}:
+
+```sh
+cd ~/src/openstreetmap-carto/
+sudo -u _renderd psql -d gis -f indexes.sql
+```
+
+It should respond with `CREATE INDEX` 16 times.
+
+## Database functions
+
+Some functions need to be loaded into the database manually. These can be added using:
+
+```sh
+cd ~/src/openstreetmap-carto/
+sudo -u _renderd psql -d gis -f functions.sql
+```
+
+### Additional Database Tables
+
+Recent versions of OSM Carto (6.0.0 onwards) [involve](https://github.com/openstreetmap-carto/openstreetmap-carto/blob/master/INSTALL.md#additional-database-tables) a database table of white-listed key/tag values which are updated with each release. This list be added / updated at any point using:
+
+```sh
+cd ~/src/openstreetmap-carto/
+sudo -u _renderd psql -d gis -f common-values.sql
+```
+
+### Shapefile download
+
+Although most of the data used to create the map is directly from the OpenStreetMap data file that you downloaded above, some shapefiles for things like low-zoom country boundaries are still needed. To download and index these, using the same account as we used previously:
+
+```sh
+cd ~/src/openstreetmap-carto/
+mkdir data
+sudo chown _renderd data
+sudo -u _renderd scripts/get-external-data.py
+```
+
+This process involves a sizable download and may take some time - not much will appear on the screen when it is running. Some data will go directly into the database, and some will go into a “data” directory below “openstreetmap-carto”. If there is a problem here, then the Natural Earth data may have moved - look at [this issue](https://github.com/nvkelso/natural-earth-vector/issues/581#issuecomment-913988101){: target=_blank} and similar ones at Natural Earth for more details. If you need to change the Natural Earth download location your copy of [this file](https://github.com/gravitystorm/openstreetmap-carto/blob/master/external-data.yml){: target=_blank} is the one to edit.
+
+### Fonts
+
+Fonts need to be installed manually, like this:
+
+```sh
+cd ~/src/openstreetmap-carto/
+scripts/get-fonts.py
+```
+
+Due to a [current issue](https://github.com/gravitystorm/openstreetmap-carto/issues/5013) you might get an error at the very end of that, but it won't adversely affect the display of any current OSM data.
+
+Our test data area (Azerbaijan) was chosen both because it was a small area and because some place names in that region have names containing non-latin characters.
+
+## Setting up your webserver
+
+### Configure renderd
+
+The config file for `renderd` on {{ dist }} is `/etc/renderd.conf`. Edit that with a text editor such as nano:
+
+```sh
+sudo nano /etc/renderd.conf
+```
+
+Add a section like the following at the end:
+
+```ini
+[s2o]
+URI=/hot/
+TILEDIR=/var/lib/mod_tile
+XML=/home/accountname/src/openstreetmap-carto/mapnik.xml
+HOST=localhost
+TILESIZE=256
+MAXZOOM=20
+```
+
+The location of the XML file `/home/accountname/src/openstreetmap-carto/mapnik.xml` will need to be changed to the actual location on your system. You can change `[s2o]` and `URI=/hot/` as well if you like. If you want to render more than one set of tiles from one server you can - just add another section like `[s2o]` with a different name referring to a different map style. If you want it to refer to a different database to the default `gis` you can, but that's out of the scope of this document. If you've only got 4Gb or so of memory, you'll also want to reduce `num_threads` to 2. `URI=/hot/` was chosen so that the tiles generated here can more easily be used in place of the HOT tile layer at OpenStreetMap.org. You can use something else here, but `/hot/` is as good as anything.
+
+The location of the Mapnik plugins directory now varies between different architectures.  You can type `` 
+
+```sh
+sudo updatedb
+locate mapnik/4.0/input
+```
+
+to find the location on your server, and then edit `/etc/renderd.conf` so that `plugins_dir` in the `[mapnik]` section is correct, perhaps something like:
+
+
+```ini
+[mapnik]
+plugins_dir=/usr/lib/aarch64-linux-gnu/mapnik/4.0/input
+```
+
+If this is set incorrectly or missing among the errors that you might get when trying to render tiles are:
+
+!!! warning ""
+    An error occurred while loading the map layer 's2o': Could not create datasource for type: 'postgis' (no datasource plugin directories have been successfully registered) encountered during parsing of layer 'landcover-low-zoom'
+
+Other errors might include tiles not rendering properly and `renderd` using an unexpectedly large amount of memory.
+
+Now that we've told `renderd` how to react to tile rendering requests we need to tell the Apache web server to send them.  Unfortunately, the configuration for this has been removed from recent versions of `mod_tile`. It can, however, currently be installed from here
+
+```sh
+cd /etc/apache2/conf-available/
+sudo wget https://raw.githubusercontent.com/openstreetmap/mod_tile/python-implementation/etc/apache2/renderd.conf
+sudo a2enconf renderd
+sudo systemctl reload apache2
+```
+
+### Making sure that you can see debug messages
+
+It'd be really useful at this point to be able to see the output from the tile rendering process, including any errors. By default, with recent `mod_tile` versions, this is turned off. To turn it on:
+
+```sh
+sudo nano /usr/lib/systemd/system/renderd.service
+```
+
+If it's not already there below `[Service]`, add:
+
+```ini
+Environment=G_MESSAGES_DEBUG=all
+```
+
+Then run these commands to reload the configuration:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl restart renderd
+sudo systemctl restart apache2
+```
+
+### Configuring Apache
+
+```sh
+sudo mkdir /var/lib/mod_tile
+sudo chown _renderd /var/lib/mod_tile
+```
+
+After doing so, restart `renderd`:
+
+```sh
+sudo /etc/init.d/renderd restart
+```
+
+If you look at the system log, you should see messages from the `renderd` service. Note that in the last couple of Debian versions, messages are no longer written to `/var/log/syslog` by default - to follow messages as they are written, do this:
+
+```sh
+sudo journalctl -ef
+```
+
+See [here](https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#changes-to-system-logging){: target=_blank}: for more details.
+
+```sh
+sudo /etc/init.d/apache2 restart
+```
+
+Using `#!sh sudo journalctl -ef` you should see a line such as:
+
+```log
+ Aug 15 12:16:08 h19 apachectl[14590]: [Fri Aug 15 12:16:08.655816 2025] [tile:notice] [pid 14590:tid 14590] Loading tile config s2o at /hot/ for zooms 0 - 20 from tile directory /var/lib/mod_tile with extension .png and mime type image/png
+```
+
+If this does not appear it probably means that the configuration file for mod_tile `/etc/apache2/conf-available/renderd.conf` is either not set up or enabled properly - see the `wget` section above.
+
+Next, point a web browser at `http://yourserveripaddress/index.html` (change `yourserveripaddress` to your actual server address). You should see "Apache2 Debian Default Page".
+
+!!! tip
+    If you don't know what IP address it will have been assigned, you can likely use `ip address` to find out – if the network configuration is not too complicated it'll probably be the `inet addr` that is not `127.0.0.1`.
+
+If you're using a server at a hosting provider then it's possible that your server's internal address will be different to the external address that has been allocated to you, but that external IP address will have already been sent to you, and it'll probably be the one that you're accessing the server on currently.
+
+Note that this is just the `http` (port 80) site – you'll need to do a little bit more Apache configuration if you want to enable `https`, but that's out of the scope of these instructions. However, if you use "Let's Encrypt" to issue certificates, then the process of setting that up can also configure the Apache HTTPS site as well.
+
+Next, point a web browser at: `http://yourserveripaddress/hot/0/0/0.png`
+
+You'll need to edit that of course if you changed `URI=/hot/` above. You should see a small map of the world. If you don't, investigate the errors that it displays. These will most likely be permissions errors, or perhaps related to accidentally missing some steps from the instructions above. If you don't get a tile and get other errors again, save the full output in a Pastebin and ask a question about the problem somewhere like [`community.openstreetmap.org`](https://community.openstreetmap.org){: target=_blank}.
+
+## Viewing tiles
+
+In order to see tiles, we’ll cheat and use an html file `sample_leaflet.html` that allows you to view a very simple map. To obtain this:
+
+```sh
+cd /var/www/html
+sudo wget https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/extra/sample_leaflet.html
+sudo nano sample_leaflet.html
+```
+
+Edit so that the IP address matches `your.server.address` rather than just saying `127.0.0.1`. That should allow you to access this server from others. Then browse to `http://your.server.address/sample_leaflet.html`.
+
+The initial map display will take a little while. You'll be able to zoom in and out, but depending on server speed some tiles may initially display as grey because they can't be rendered in time for the browser. However, once done, they’ll be ready for the next time that they are needed. If you look in the system log you should see requests for tiles.
+
+If desired, you can increase the setting `ModTileMissingRequestTimeout` in `/etc/apache2/conf-available/renderd.conf` from 10 seconds to 60 or perhaps even more, in order to wait longer for tiles to be rendered (where there is no old one) in the background before a grey tile is given to the user. Make sure you `#!sh sudo service renderd restart` and `#!sh sudo service apache2 restart` after changing it.  You may actually wish to measure the effect of changes to the other variables there.
+
+Congratulations. Head over to the [using tiles](/using-tiles/index.md) section to create a map that uses your new tile server.

--- a/docs/en/serving-tiles/manually-building-a-tile-server-debian-13-flex.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-debian-13-flex.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Manually building a tile server (Debian 13)
+title: Manually building a tile server (Debian 13, flex)
 dist: Debian 13
 dl_timestamp: "2025-08-15T12:40:00Z"
 lang: en
@@ -9,7 +9,7 @@ lang: en
 # {{ title }}
 
 !!! info ""
-    This page describes how to install, setup and configure all the necessary software to operate your own tile server. These step-by-step instructions were written for [Debian Linux](https://www.debian.org/){: target=_blank} 13 (trixie), and were tested in August 2025.
+    This page describes how to install, setup and configure all the necessary software to operate your own tile server. These step-by-step instructions were written for [Debian Linux](https://www.debian.org/){: target=_blank} 13 (trixie), using v6.0.0 of OSM Carto and were tested in June 2026.
 
 ## Software installation
 

--- a/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
+++ b/docs/en/serving-tiles/manually-building-a-tile-server-debian-13.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Manually building a tile server (Debian 13)
+title: Manually building a tile server (Debian 13, pgsql)
 dist: Debian 13
 dl_timestamp: "2025-08-15T12:40:00Z"
 lang: en
@@ -9,7 +9,7 @@ lang: en
 # {{ title }}
 
 !!! info ""
-    This page describes how to install, setup and configure all the necessary software to operate your own tile server. These step-by-step instructions were written for [Debian Linux](https://www.debian.org/){: target=_blank} 13 (trixie), and were tested in August 2025.
+    This page describes how to install, setup and configure all the necessary software to operate your own tile server. These step-by-step instructions were written for [Debian Linux](https://www.debian.org/){: target=_blank} 13 (trixie), using v5.9.0 of OSM Carto and were tested in August 2025.
 
 ## Software installation
 
@@ -135,7 +135,7 @@ git pull --all
 git switch --detach v5.9.0
 ```
 
-The "git switch" is needed because that's the latest release that you can see at OpenStreetMap, but OSM Carto has actually moved to a different database format. See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.  The old format is called `pgsql`, the new one `flex`; later we'll get a [warning](https://osm2pgsql.org/doc/faq.html#the-pgsql-output-is-deprecated-what-does-that-mean) from `osm2pgsql` about that.
+The "git switch" is needed because that's not the latest release from OSM Carto - it has moved to a different database format. See OSM Carto's [INSTALL.md](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md) for the newer version.  The old format is called `pgsql`, the new one `flex`; later we'll get a [warning](https://osm2pgsql.org/doc/faq.html#the-pgsql-output-is-deprecated-what-does-that-mean) from `osm2pgsql` about that.
 
 Next, we'll check that we have installed a suitable version of the `carto` compiler.
 

--- a/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
+++ b/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
@@ -273,10 +273,10 @@ The script to perform the update can be added to root's crontab.  First, amend `
 Then add to your non-root accounts's crontab something like:
 
 ```sh
-04 04  *   *   *     /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
+04 09  *   *   *     /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
 ```
 
-This example runs once per day at 04:04 every morning.  There's no point in running it more than once per day, since Geofabrik updates are only released daily.
+This example runs once per day at 09:04 every morning.  There's no point in running it more than once per day, since Geofabrik updates are only released daily.
 
 ## Using minutely updates from openstreetmap.org
 

--- a/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
+++ b/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
@@ -22,10 +22,12 @@ First, from whichever non-root account you are using, download the data:
 # if it doesn't already exist
 mkdir ~/data
 cd ~/data
-wget http://download.geofabrik.de/europe/great-britain/england/greater-london-latest.osm.pbf
+wget http://download.geofabrik.de/europe/united-kingdom/england/greater-london-latest.osm.pbf
 ```
 
-Next, load the database.  The numbers here for processes and memory can be varied to match the system being used:
+Next, load the database.  The actual parameters used will depend on whether the `pgsql` output from `osm2pgsql` is being used (used by OSM Carto versions up to 5.9.0) or whether the `flex` output is (OSM Carto versions 6.0.0 and above).  In addition, the numbers here for processes and memory can be varied to match the system being used.
+
+For `pgsql`:
 
 ```sh
 sudo -u _renderd \
@@ -34,6 +36,17 @@ sudo -u _renderd \
         ~/src/openstreetmap-carto/openstreetmap-carto.lua \
     -C 3000 --number-processes 4 \
     -S ~/src/openstreetmap-carto/openstreetmap-carto.style \
+    ~/data/greater-london-latest.osm.pbf
+```
+
+For `flex`:
+
+```sh
+sudo -u _renderd \
+    osm2pgsql -O flex \
+    -S        ~/src/openstreetmap-carto/openstreetmap-carto-flex.lua \
+    -d gis --create --slim  \
+    -C 3000 --number-processes 4 \
     ~/data/greater-london-latest.osm.pbf
 ```
 
@@ -51,11 +64,11 @@ sudo -u _renderd \
 That produces output something like this:
 
 ```log
-2022-04-24 23:32:42 [INFO]: Initialised updates for service 'http://download.geofabrik.de/europe/great-britain/england/greater-london-updates'.
+2022-04-24 23:32:42 [INFO]: Initialised updates for service 'http://download.geofabrik.de/europe/united-kingdom/england/greater-london-updates'.
 2022-04-24 23:32:42 [INFO]: Starting at sequence 3314 (2022-04-23 20:21:53+00:00).
 ```
 
-In this example, the date shown there corresponds to the date visible [on this page](http://download.geofabrik.de/europe/great-britain/england/greater-london.html){: target=_blank} when the data was downloaded.
+In this example, the date shown there corresponds to the date visible [on this page](http://download.geofabrik.de/europe/united-kingdom/england/greater-london.html){: target=_blank} when the data was downloaded.
 
 ### Creating scripts to apply updates
 
@@ -93,7 +106,7 @@ Next:
 sudo nano /usr/local/sbin/update_tiles.sh
 ```
 
-initially, this script should contain:
+initially, this script should contain something like (for `pgsql`):
 
 ```sh title="update_tiles.sh"
 #!/bin/bash
@@ -109,6 +122,22 @@ osm2pgsql-replication \
     --expire-tiles=1-20 \
     --expire-output=/var/cache/renderd/dirty_tiles.txt
 ```
+
+A `flex` version would be something like:
+
+```sh title="update_tiles.sh"
+#!/bin/bash                                                                                                   
+osm2pgsql-replication \
+    update -d gis \
+    --post-processing /usr/local/sbin/expire_tiles.sh \
+    --max-diff-size 10  --  \
+    -S /home/renderaccount/src/openstreetmap-carto/openstreetmap-carto-flex.lua \
+    -C 2500 --number-processes 4 \
+    --expire-tiles=1-20 \
+    --expire-output=/var/cache/renderd/dirty_tiles.txt
+```
+
+References to `renderaccount` need changing to the actual location based on the account that you are using.
 
 Everything in the `osm2pgsql-replication update` line after `--` is passed as parameters to osm2pgsql - they will all need to match what the database was loaded with in the first place.  Before the `--`, `-d gis` just defines what database we're using and `--max-diff-size 10` how much data to process at once, but note that osm2pgsql-replication will actually repeat downloading data and updating the database until there is no more to process, which may take some time.  The `--max diff-size` determines how much data is fetched on each iteration. The `--post-processing /usr/local/sbin/expire_tiles.sh` just calls our other script.
 
@@ -149,7 +178,7 @@ In another session:
 sudo tail -f /var/log/syslog
 ```
 
-or if you are using Debian 12, which does not have a "syslog" file by default:
+or if you are using a system which does not have a "syslog" file by default, such as Debian 12 or above:
 
 ```sh
 sudo journalctl -ef
@@ -173,7 +202,7 @@ If there are no pending updates (Geofabrik updates for these files appear daily)
 If there are pending updates, then instead you will see something like:
 
 ```log
-2022-06-05 16:29:32 [INFO]: Using replication service 'http://download.geofabrik.de/europe/great-britain/england/greater-london-updates'. Current sequence 3355 (2022-06-03 20:21:26+00:00).
+2022-06-05 16:29:32 [INFO]: Using replication service 'http://download.geofabrik.de/europe/united-kingdom/england/greater-london-updates'. Current sequence 3355 (2022-06-03 20:21:26+00:00).
 2022-06-05 16:29:33  osm2pgsql version 1.6.0
 2022-06-05 16:29:33  Database version: 14.3 (Ubuntu 14.3-0ubuntu0.22.04.1)
 2022-06-05 16:29:33  PostGIS version: 3.2
@@ -239,12 +268,12 @@ Jun  5 16:36:58 ubuntuvm75 renderd[5838]: Connection 0, fd 5 closed, now 0 left,
 
 ### Running every day
 
-The script to perform the update can be added to root's crontab.  First, amend `update_tiles.sh` to do some error checking at startup, and to append a summary to a logfile only.  You can get a copy of that from [here](https://github.com/SomeoneElseOSM/mod_tile/blob/switch2osm/update_tiles.sh){: target=_blank}. Again, change "renderaccount" to the name of whatever non-root account you are using here.  You can also adjust the number of threads and the amount of memory cache used.
+The script to perform the update can be added to root's crontab.  First, amend `update_tiles.sh` to do some error checking at startup, and to append a summary to a logfile only.  You can get a copy of that from [here](https://github.com/SomeoneElseOSM/mod_tile/blob/switch2osm/update_tiles.sh){: target=_blank} for `pgsql` or [here](https://github.com/SomeoneElseOSM/mod_tile/blob/switch2osm/update_tiles_flex.sh){: target=_blank} for `flex` (as noted above, the `osm2pgsql` parameters are different). Again, change "renderaccount" to the name of whatever non-root account you are using here.  You can also adjust the number of threads and the amount of memory cache used.
 
-Then add to root's crontab:
+Then add to your non-root accounts's crontab something like:
 
 ```sh
-04 04  *   *   *     sudo -u _renderd /usr/local/sbin/update_tiles.sh
+04 04  *   *   *     /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
 ```
 
 This example runs once per day at 04:04 every morning.  There's no point in running it more than once per day, since Geofabrik updates are only released daily.

--- a/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
+++ b/docs/en/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md
@@ -321,10 +321,10 @@ Again, note that "osm2pgsql-replication" will actually repeat downloading data a
 2022-06-05 22:30:47 [INFO]: Data imported until 2022-06-05 21:45:42+00:00. Backlog remaining: 0:45:05.948787
 ```
 
-The script to perform the update can be edited as above to output a summary to a logfile and added to root's crontab:
+The script to perform the update can be edited as above to output a summary to a logfile and added to your non-root accounts's crontab:
 
 ```sh
-*/5 *  *   *   *     sudo -u _renderd /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
+*/5 *  *   *   *     /usr/local/sbin/update_tiles.sh >> /var/log/tiles/run.log
 ```
 
 As we're updating based on minutely updates, and we've made the script check that it is not already running before trying to apply updates, we can run this more often than once per day; in this case every 5 minutes.

--- a/docs/en/serving-tiles/updating-as-people-edit-osmosis.md
+++ b/docs/en/serving-tiles/updating-as-people-edit-osmosis.md
@@ -54,20 +54,28 @@ That will need to be changed to whatever is the non-root username below which th
 
 Also make sure that the script does NOT contain `-e$EXPIRY_METAZOOM:$EXPIRY_METAZOOM`. If it does, change the `:` to a `-`: `-e$EXPIRY_METAZOOM-$EXPIRY_METAZOOM`.
 
-Something else to consider is that you'll probably want to edit the OSM2PGSQL_OPTIONS to refer to the lua tag transform script that you used when loading the database, and the `.style` file that determines what columns are created. There may be other parameters that you need to pass here too depending on what you used when creating the database. Change `/path/to/` to the actual path, of course:
+Something else to consider is that you'll probably want to edit the OSM2PGSQL_OPTIONS to be correct for the database type and the lua tag transform script that you used when loading the database, and for `pgsql` the `.style` file that determines what columns are created. There may be other parameters that you need to pass here too depending on what you used when creating the database. Change `/path/to/` to the actual path, of course:
+
+(`pgsql`)
 
 ```sh
 OSM2PGSQL_OPTIONS="-d $DBNAME --tag-transform-script /path/to/src/openstreetmap-carto/openstreetmap-carto.lua -S /path/to/src/openstreetmap-carto/openstreetmap-carto.style"
 ```
 
-Next, we'll create the log directory for tile expiry logs, and change the ownership to the username used for rendering tiles (for Debian 11, this will be `_renderd`). The script must also be run as this account, and because this account may be different to where the software is downloaded, we'll pass the complete location of the script - modify `/path/to` to whatever is correct.
+(`flex`)
+
+```sh
+OSM2PGSQL_OPTIONS="-d $DBNAME -S /path/to/openstreetmap-carto/openstreetmap-carto-flex.lua"
+```
+
+Next, we'll create the log directory for tile expiry logs, and change the ownership to the username used for rendering tiles (for Debian 11 and above and later Ubuntu, this will be `_renderd`). The script must also be run as this account, and because this account may be different to where the software is downloaded, we'll pass the complete location of the script - modify `/path/to` to whatever is correct.
 
 The parameter passed to `openstreetmap-tiles-update-expire` should be the age of the data originally loaded. If you downloaded data from Geofabrik it should be what the "and contains all OSM data up" date was on e.g. <http://download.geofabrik.de/asia/azerbaijan.html>{: target=_blank} when you downloaded the data.
 
 ```sh
 sudo mkdir /var/log/tiles
-sudo chown renderaccount /var/log/tiles
-sudo -u renderaccount /path/to/src/mod_tile/openstreetmap-tiles-update-expire 2020-11-14T21:42:02Z
+sudo chown _renderd /var/log/tiles
+sudo -u _renderd /path/to/src/mod_tile/openstreetmap-tiles-update-expire 2026-06-12T20:21:15Z
 ```
 
 The last line of the output that you get should look something like
@@ -87,7 +95,7 @@ tail -f /var/log/tiles/run.log
 On another run:
 
 ```sh
-sudo -u renderaccount /path/to/src/mod_tile/openstreetmap-tiles-update-expire
+sudo -u _renderd /path/to/src/mod_tile/openstreetmap-tiles-update-expire
 ```
 
 modifying that like with the correct account and path as was done previously; but this time with no parameter.
@@ -115,13 +123,13 @@ The `replag` value shown is the replication lag; by default, an hours-worth of d
 
 Run `openstreetmap-tiles-update-expire` again in the same way; you should see that `replag` is an hour less than it was.
 
-Next, we'll set up `openstreetmap-tiles-update-expire` in crontab to run every few minutes. We'll want this to run from the crontab of the user that does the rendering, so on Debian 11 we'll need to do this:
+Next, we'll set up `openstreetmap-tiles-update-expire` in crontab to run every few minutes. We'll want this to run from the crontab of the user that does the rendering, so on Debian 11 and above we'll need to do this:
 
 ```sh
 sudo -u _renderd crontab -e
 ```
 
-You may see a message "problems with history file" - don't worry if you do. On non-Debian 11 systems, we will probably be able to run `crontab -e` directly from the username that is rendering tiles. The first time you run `crontab -e` you may be asked to choose an editor. Go down to the end of the file. Lines starting with `#` are comments. The last comment line is:
+You may see a message "problems with history file" - don't worry if you do. On earlier systems, we will probably be able to run `crontab -e` directly from the username that is rendering tiles. The first time you run `crontab -e` you may be asked to choose an editor. Go down to the end of the file. Lines starting with `#` are comments. The last comment line is:
 
 ```sh
 # m h  dom mon dow   command

--- a/docs/en/serving-tiles/updating-as-people-edit-pyosmium.md
+++ b/docs/en/serving-tiles/updating-as-people-edit-pyosmium.md
@@ -8,7 +8,7 @@ lang: en
 
 Every day there are millions of new map updates so to prevent a map becoming "stale" you can refresh the data used to create map tiles regularly.
 
-Using osm2pgsql (version 1.4.2 or above) it's now much easier to do this than it was previously.  Suitable versions are distributed as part of Ubuntu 22.04 and Debian 12, and it can also be obtained by following [these instructions](https://osm2pgsql.org/doc/install.html){: target=_blank}.
+Using osm2pgsql (version 1.4.2 or above) it's now much easier to do this than it was previously.  Suitable versions are distributed as part of Ubuntu 22.04 and Debian 12 and later, and it can also be obtained by following [these instructions](https://osm2pgsql.org/doc/install.html){: target=_blank}.
 
 A simpler, but less flexible, method to update a database is to use "osm2pgsql-replication", described [here](/serving-tiles/updating-as-people-edit-osm2pgsql-replication.md). In this example we'll use "PyOsmium" to update a database initially loaded from Geofabrik with minutely updates from planet.openstreetmap.org.
 
@@ -38,7 +38,7 @@ sudo systemctl restart apache2
 
 Important note - the tile expiry script used below assumes that tiles are written below `/var/cache/renderd/`. If `/etc/renderd.conf` specifies another location, you'll need to modify it before expiring tiles using the scripts you're going to create here.  Because that directory will always exist, we'll also use it for workfiles needed by "pyosmium".
 
-For the sake of this example, we'll assume that you've loaded your database in this way:
+For the sake of this example, we'll assume that you've loaded your database in this way (`pgsql`):
 
 ```sh
 sudo -u _renderd \
@@ -50,7 +50,18 @@ sudo -u _renderd \
     ~/data/greater-london-latest.osm.pbf
 ```
 
-The data to load was obtained from a page such as [this one](http://download.geofabrik.de/europe/united-kingdom/england/greater-london.html){: target=_blank}, which says something like "... and contains all OSM data up to 2023-07-02T20:21:43Z". We'll use that date when setting up replication below:
+or like this (`flex`):
+
+```sh
+sudo -u _renderd \
+    osm2pgsql -O flex \
+    -S        ~/src/openstreetmap-carto/openstreetmap-carto-flex.lua \
+    -d gis --create --slim  \
+    -C 3000 --number-processes 4 \
+    ~/data/greater-london-latest.osm.pbf
+```
+
+The data to load was obtained from a page such as [this one](http://download.geofabrik.de/europe/united-kingdom/england/greater-london.html){: target=_blank}, which says something like "... and contains all OSM data up to 2026-06-12T20:21:15Z". We'll use that date when setting up replication below:
 
 ```sh
 sudo mkdir /var/cache/renderd/pyosmium
@@ -59,7 +70,7 @@ sudo mkdir /var/log/tiles
 sudo chown _renderd /var/log/tiles
 cd /var/cache/renderd/pyosmium
 sudo apt install pyosmium
-sudo -u _renderd pyosmium-get-changes -D 2023-07-02T20:21:43Z -f sequence.state -v
+sudo -u _renderd pyosmium-get-changes -D 2026-06-12T20:21:15Z -f sequence.state -v
 ```
 
 The last line creates a "sequence.state" file.  The actual date used in that line will need to match the data that you downloaded.
@@ -80,22 +91,28 @@ sudo apt install python3-shapely python3-lxml
 
 ## Applying updates
 
-A script to actually apply updates has been created [here](https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/call_pyosmium.sh){: target=_blank}. A good place to create that is `/usr/local/sbin`. That will need some customisation:
+A script to actually apply updates has been created [here](https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/call_pyosmium.sh){: target=_blank} for `pgsql` or [here](https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/call_pyosmium_flex.sh){: target=_blank} for `flex` (as noted previously, the `osm2pgsql` parameters are different).  A good place to create that is `/usr/local/sbin`. That will need some customisation:
 
 * If you're not using "trim_osc.py", just remove the section of code between the "Trim the downloaded changes" comment and the "The osm2pgsql append line" one.
 
 * If you are using "trim_osc.py" you'll need to make sure that TRIM_BIN points to the correct location and TRIM_REGION_OPTIONS matches the area that you are interested in (the default in the script covers IE+GB).
 
-* The parameters to "osm2pgsql --append" will need customising to match the server you're using (amount of memory allocated, number of threads, etc.)
+* The parameters to "osm2pgsql --append" will need customising to match your database (`pgsql` or `flex`) and the server you're using (amount of memory allocated, number of threads, etc.)
 
 * The parameters passed to "render_expired" will need to be customised (how many zoom levels to process, and what to do with dirty tiles at each level)
 
-A script to display the current database replication lag is available [here](https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/pyosmium_replag.sh){: target=_blank}, which is based on the "mod_tile" one that is shipped as an example with the mod_tile source. `pyosmium_replag` displays the replication lag in seconds; `pyosmium_replag -h` displays the replication lag in hours (or if less than an hour minutes, or seconds). It is suggested to also create that in `/usr/local/sbin`. Don't forget to make both scripts executable.
+A script to display the current database replication lag is available [here](https://raw.githubusercontent.com/SomeoneElseOSM/mod_tile/switch2osm/pyosmium_replag.sh){: target=_blank}, which is based on the "mod_tile" one that is shipped as an example with the mod_tile source. `pyosmium_replag.sh` displays the replication lag in seconds; `pyosmium_replag.sh -h` displays the replication lag in hours (or if less than an hour minutes, or seconds). It is suggested to also create that in `/usr/local/sbin`. Don't forget to make both scripts executable.
 
 To run the script once:
 
 ```sh
 sudo -u _renderd /usr/local/sbin/call_pyosmium.sh
+```
+
+or
+
+```sh
+sudo -u _renderd /usr/local/sbin/call_pyosmium_flex.sh
 ```
 
 As it runs, it creates workfiles (and the verbose output from the commands that it runs) in `/var/cache/renderd/pyosmium`. At completion you should see something like:
@@ -126,10 +143,16 @@ The script to perform the update can be added to the crontab of the `_renderd` a
 sudo -u _renderd crontab -e
 ```
 
-and then add:
+and then add as appropriate:
 
 ```sh
 */5 *  *   *   *     /usr/local/sbin/call_pyosmium.sh >> /var/log/tiles/run.log
+```
+
+or
+
+```sh
+*/5 *  *   *   *     /usr/local/sbin/call_pyosmium_flex.sh >> /var/log/tiles/run.log
 ```
 
 The script checks that it is not already running before trying to apply updates, so can run it fairly frequently; in this case every 5 minutes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,8 @@ nav:
       # - Serving tiles: serving-tiles/index.md
       - serving-tiles/index.md
       - Manually:
-          - Debian 13: serving-tiles/manually-building-a-tile-server-debian-13.md
+          - Debian 13 flex: serving-tiles/manually-building-a-tile-server-debian-13-flex.md
+          - Debian 13 pgsql: serving-tiles/manually-building-a-tile-server-debian-13.md
           - Debian 12: serving-tiles/manually-building-a-tile-server-debian-12.md
           - Debian 11: serving-tiles/manually-building-a-tile-server-debian-11.md
           - Ubuntu 24.04: serving-tiles/manually-building-a-tile-server-ubuntu-24-04-lts.md


### PR DESCRIPTION
Added page for Debian 13 flex to complement Debian 13 pgsql
Added detail to each to say which is which, and differentiate them in the menus
Updated the three "updating" pages to know about flex as opposed to pgsql, and tested each one.
Also fixed a number of other minor issues along the way, sometimes prompted by external changes (such as the move of lower Geofabrik areas from great-britain to united-kingom).
